### PR TITLE
Refactor types for `style` and `styled`, fixing TS autocomplete issues.

### DIFF
--- a/src/qwik-styled.ts
+++ b/src/qwik-styled.ts
@@ -122,7 +122,7 @@ export type Tags =
 
 export type QwikStyledComponent<Tag extends Tags = 'div'> = FunctionComponent<
 	QwikIntrinsicElements[Tag]
-> & {class: string} & string
+> & {class: string}
 
 export const isStyled = (o: any): o is QwikStyledComponent =>
 	typeof o === 'function' && 'class' in o
@@ -130,7 +130,7 @@ export const isStyled = (o: any): o is QwikStyledComponent =>
 export const styled = <Tag extends Tags>(
 	Tag: Tag,
 	myClassName: string
-): FunctionComponent<QwikIntrinsicElements[Tag]> & {class: string} => {
+): QwikStyledComponent<Tag> => {
 	const Lite = ({class: extraClass, ...props}: {[x: string]: any}) => {
 		let classes: string[] | undefined
 		const check = (cl?: string | {[c: string]: boolean}) => {


### PR DESCRIPTION
`style` and `styled` were not giving proper autocomplete because the first arg was being resolved to type `any`.

This PR fixes a few things:
- It refactors the first arg to be `ComplexStyleRule | Array<QwikStyledComponent<any>>`. Typescript automatically merges array types, so there's no need to have them split up like that. The `any` is needed because it was `"div"` by default, which is not the intention here.
- Refactors `style` to use function overloading for tagged template literal stuff. `...args` should not be passed when `cssArg` is passed, so a literal is better here for the type.
- Extracts a function for checking whether an argument is a template literal argument.
- Refactors `StyledProxy` to use the same overloading as `StyleFunction`.
- Refactors `styled` to call `style` in a new way. The check there is unfortunately necessary due to how TypeScript overloads work.
- Removes `| string` from `QwikStyledComponent`. `QwikStyledComponent` does not implement `string`, it implements `toString`. This will still let it work with the tagged template literals as the type for them is `...args: any[]`.

This should fix any autocomplete problems with the `style` function and `styled` function.

Closes #5.