### PR TITLE
I think this will fix types?

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -1,7 +1,7 @@
 import {keyframes, StyleRule} from '@vanilla-extract/css'
 import {compile} from 'stylis'
-import {QwikStyledComponent} from './qwik-styled'
-import {ClassNames} from './ve-style'
+import {type QwikStyledComponent} from './qwik-styled'
+import {type ClassNames} from './ve-style'
 
 export const veClassRE = /^[a-zA-Z0-9_./]*[a-z0-9]{6}\d+$/
 export const veMultiClassRE = /^([a-zA-Z0-9_./]*[a-z0-9]{6}\d+( |$)){2,}/

--- a/src/css.ts
+++ b/src/css.ts
@@ -1,5 +1,7 @@
 import {keyframes, StyleRule} from '@vanilla-extract/css'
 import {compile} from 'stylis'
+import {QwikStyledComponent} from './qwik-styled'
+import {ClassNames} from './ve-style'
 
 export const veClassRE = /^[a-zA-Z0-9_./]*[a-z0-9]{6}\d+$/
 export const veMultiClassRE = /^([a-zA-Z0-9_./]*[a-z0-9]{6}\d+( |$)){2,}/
@@ -22,7 +24,7 @@ const changeAnimName = (rule: StyleRule, name: string, real: string) => {
 }
 export const css = (
 	tpl: TemplateStringsArray,
-	...expr: string[]
+	...expr: (StyleRule | QwikStyledComponent | ClassNames)[]
 ): StyleRule => {
 	let output = tpl[0]
 	for (let i = 1; i < tpl.length; i++) {

--- a/src/qwik-styled.ts
+++ b/src/qwik-styled.ts
@@ -122,7 +122,7 @@ export type Tags =
 
 export type QwikStyledComponent<Tag extends Tags = 'div'> = FunctionComponent<
 	QwikIntrinsicElements[Tag]
-> & {class: string} & string
+> & {class: string}
 
 export const isStyled = (o: any): o is QwikStyledComponent =>
 	typeof o === 'function' && 'class' in o


### PR DESCRIPTION
I looked at https://github.com/wmertens/styled-vanilla-extract/pull/9 and there was a lot of stuff I didn't understand happening -- I tried to build off of it but I mostly got lost. I was able to understand this, though:

> `style` and `styled` were not giving proper autocomplete because the first arg was being resolved to type `any`

So, I tried to see if I could fix just that issue without needing to do anything overly complex. Hopefully, this fixes #5. I gotta try it out first.

Edit: Seems to fix autocomplete for me! At least, using the local path dependency...