### PR TITLE
fix: properly resolve file path in nx workspace

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -229,12 +229,17 @@ export function vanillaExtractPlugin({
 					}
 
 					;({filePath} = args.fileScope)
-					const rootRelativeId = `${filePath}${
+					const projectRootRelativeId = `${filePath}${
 						config.command === 'build' || (ssr && forceEmitCssInSsrBuild)
 							? virtualExtCss
 							: virtualExtJs
 					}`
-					const absoluteId = getAbsoluteVirtualFileId(rootRelativeId)
+					const absoluteId = getAbsoluteVirtualFileId(projectRootRelativeId);
+					// using relative path to the workspace root in a posix style
+					const cwdRelativeId =  path.relative(process.cwd(), absoluteId)
+						.split(path.sep)
+						.join(path.posix.sep);
+
 					if (
 						server &&
 						cssMap.has(absoluteId) &&
@@ -269,7 +274,7 @@ export function vanillaExtractPlugin({
 
 					// We use the root relative id here to ensure file contents (content-hashes)
 					// are consistent across build machines
-					return `import "${rootRelativeId}";`
+					return `import "${cwdRelativeId}";`
 				},
 			})
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -234,11 +234,12 @@ export function vanillaExtractPlugin({
 							? virtualExtCss
 							: virtualExtJs
 					}`
-					const absoluteId = getAbsoluteVirtualFileId(projectRootRelativeId);
+					const absoluteId = getAbsoluteVirtualFileId(projectRootRelativeId)
 					// using relative path to the workspace root in a posix style
-					const cwdRelativeId =  path.relative(process.cwd(), absoluteId)
+					const cwdRelativeId = path
+						.relative(process.cwd(), absoluteId)
 						.split(path.sep)
-						.join(path.posix.sep);
+						.join(path.posix.sep)
 
 					if (
 						server &&


### PR DESCRIPTION
In Nx workspaces applications live under the nested dir (e.g. `apps/myapp`). Looks like the path resolution is broken in this case, specifically at this line https://github.com/wmertens/styled-vanilla-extract/blob/efa92bb39276ddab51de6b792dee051b5abe6664/src/vite.ts#L272 . `rootRelativeId` there is relative to project root, not workspace, thus the import statement points to an invalid file

To reproduce:
1. run `npx create-nx-workspace@latest --preset=qwik-nx`
2. install vanilla extract in the same way it's added to regular qwik project: add vanilla extract dependencies to package.json, plugin to the vite config and a sample route that uses it
3. notice the error
