### PR TITLE
fix hmr : invalidate css files

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -281,8 +281,13 @@ export function vanillaExtractPlugin({
 						const modules = Array.from(
 							moduleGraph.getModulesByFile(absoluteIdNoExt) || []
 						)
+						const virtualCSSModules = Array.from(
+							moduleGraph.getModulesByFile(
+								`${absoluteIdNoExt}${virtualExtCss}`
+							) || []
+						)
 
-						for (const module of modules) {
+						for (const module of [...modules, ...virtualCSSModules]) {
 							if (module) {
 								moduleGraph.invalidateModule(module)
 


### PR DESCRIPTION
fixes #11 

In https://github.com/wmertens/styled-vanilla-extract/commit/5785cc85a3734ee0bce87c5b4070b2a4933b7e9c the handleHotUpdate hook was removed.

```ts
// Re-parse .css.ts files when they change
async handleHotUpdate({file, modules}) {
	if (!cssFileFilter.test(file)) return
	try {
		const virtuals: any[] = []
		const invalidate = (type: string) => {
			const found = server.moduleGraph.getModulesByFile(`${file}${type}`)
			found?.forEach(m => {
				virtuals.push(m)
				return server.moduleGraph.invalidateModule(m)
			})
		}
		invalidate(virtualExtCss)
		invalidate(virtualExtJs)
		// load new CSS
		await server.ssrLoadModule(file)
		return [...modules, ...virtuals]
	} catch (e) {
		// eslint-disable-next-line no-console
		console.error(e)
		throw e
	}
}
```
It was responsible of invalidating .vanilla.css files. 
Therefore it was required to do a full restart of the vite dev server to see style updates.

This PR reintroduce the invalidation of `.vanilla.css` files in the transform hook
 to fix the HMR.